### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
         "lock",
         "unlock",
         "screen",
-        "android",
+        "android"
     ],
     "platforms": [
-        "android",
+        "android"
     ],
     "engines": [],
     "englishdoc": ""


### PR DESCRIPTION
 Cordova shows errors when try to install this plugin. File package.json must be actual JSON, not just JavaScript.